### PR TITLE
Add config file, withe items and weapons autosell with onditions, human player detection

### DIFF
--- a/conf/mod_junk_to_gold.conf.dist
+++ b/conf/mod_junk_to_gold.conf.dist
@@ -1,0 +1,25 @@
+[worldserver]
+#
+# JunkToGold (mod-junk-to-gold)
+# Enables/disables the module.
+# 1 = enabled, 0 = disabled
+#
+JunkToGold.Enable = 1
+
+# Print a log line on startup / reload
+JunkToGold.Announce = 1
+
+# Automatically sell some items in addition to grey ones
+#
+# If enabled, white-quality items (quality=1) that are
+# STRICTLY worse than what the player already has equipped
+# will be sold on loot. (Based on quality, then item level.)
+#
+# 0 = disabled (default); 1 = enabled
+JunkToGold.SellCommonIfWorse = 0
+
+# Also sell WEAPONS (white-quality) if they are worse than equipped
+# Criteria for weapons: Quality > DPS > Item level > Required level.
+# WARNING: keep the weapon if any possible slot is empty or already has an item >=
+# 0 = disabled (default); 1 = enabled
+JunkToGold.SellWeaponsIfWorse = 0

--- a/conf/mod_junk_to_gold.conf.dist
+++ b/conf/mod_junk_to_gold.conf.dist
@@ -23,3 +23,7 @@ JunkToGold.SellCommonIfWorse = 0
 # WARNING: keep the weapon if any possible slot is empty or already has an item >=
 # 0 = disabled (default); 1 = enabled
 JunkToGold.SellWeaponsIfWorse = 0
+
+# Enable/disable selling for human-controlled players
+# 1 = enabled (default), 0 = disabled (sell for bots only if you use Playerbots)
+JunkToGold.EnableForHumans = 1

--- a/src/j2g_conf.cpp
+++ b/src/j2g_conf.cpp
@@ -1,0 +1,45 @@
+#include "j2g_conf.h"
+#include "Config.h"
+#include "Log.h"
+
+namespace
+{
+    bool sEnabled  = true;
+    bool sAnnounce = true;
+	bool sSellCommonIfWorse = false;
+	bool sSellWeaponsIfWorse = false;
+}
+
+namespace J2G
+{
+    bool IsEnabled()
+    {
+        return sEnabled;
+    }
+
+    void LoadConfig()
+    {
+        sEnabled  = sConfigMgr->GetOption<bool>("JunkToGold.Enable",   true);
+        sAnnounce = sConfigMgr->GetOption<bool>("JunkToGold.Announce", true);
+		sSellCommonIfWorse = sConfigMgr->GetOption<bool>("JunkToGold.SellCommonIfWorse", false);
+		sSellWeaponsIfWorse = sConfigMgr->GetOption<bool>("JunkToGold.SellWeaponsIfWorse", false);
+
+        if (sAnnounce)
+            LOG_INFO("module", "mod-junk-to-gold: {}", sEnabled ? "enabled" : "disabled");
+    }
+
+    bool SellCommonIfWorse()
+    {
+        return sSellCommonIfWorse;
+    }
+
+    bool SellWeaponsIfWorse()
+    {
+        return sSellWeaponsIfWorse;
+    }
+
+    void World::OnAfterConfigLoad(bool /*reload*/)
+    {
+        LoadConfig();
+    }
+}

--- a/src/j2g_conf.cpp
+++ b/src/j2g_conf.cpp
@@ -6,6 +6,7 @@ namespace
 {
     bool sEnabled  = true;
     bool sAnnounce = true;
+	bool sEnableForHumans = true;
 	bool sSellCommonIfWorse = false;
 	bool sSellWeaponsIfWorse = false;
 }
@@ -21,6 +22,7 @@ namespace J2G
     {
         sEnabled  = sConfigMgr->GetOption<bool>("JunkToGold.Enable",   true);
         sAnnounce = sConfigMgr->GetOption<bool>("JunkToGold.Announce", true);
+		sEnableForHumans = sConfigMgr->GetOption<bool>("JunkToGold.EnableForHumans", true);
 		sSellCommonIfWorse = sConfigMgr->GetOption<bool>("JunkToGold.SellCommonIfWorse", false);
 		sSellWeaponsIfWorse = sConfigMgr->GetOption<bool>("JunkToGold.SellWeaponsIfWorse", false);
 
@@ -28,6 +30,11 @@ namespace J2G
             LOG_INFO("module", "mod-junk-to-gold: {}", sEnabled ? "enabled" : "disabled");
     }
 
+    bool EnableForHumans()
+    {
+        return sEnableForHumans;
+    }
+	 
     bool SellCommonIfWorse()
     {
         return sSellCommonIfWorse;

--- a/src/j2g_conf.h
+++ b/src/j2g_conf.h
@@ -6,6 +6,9 @@ namespace J2G
 {
     bool IsEnabled();
 
+    // Enable/disable selling for human-controlled players
+    bool EnableForHumans();
+
     bool SellCommonIfWorse();
 
     bool SellWeaponsIfWorse();

--- a/src/j2g_conf.h
+++ b/src/j2g_conf.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "ScriptMgr.h"
+
+namespace J2G
+{
+    bool IsEnabled();
+
+    bool SellCommonIfWorse();
+
+    bool SellWeaponsIfWorse();
+
+    void LoadConfig();
+
+    class World final : public WorldScript
+    {
+    public:
+        World() : WorldScript("J2G_WorldScript") {}
+        void OnAfterConfigLoad(bool /*reload*/) override;
+    };
+}

--- a/src/mod_junk_to_gold.cpp
+++ b/src/mod_junk_to_gold.cpp
@@ -173,7 +173,6 @@ class JunkToGold : public PlayerScript
 public:
     JunkToGold() : PlayerScript("JunkToGold") {}
 
-    //void OnPlayerLootItem(Player* player, Item* item, uint32 count, ObjectGuid /*lootguid*/) override
 	void OnPlayerLootItem(Player* player, Item* item, uint32 count, ObjectGuid /*lootGuid*/) override
     {
         // --- Global Toggle ---

--- a/src/mod_junk_to_gold.cpp
+++ b/src/mod_junk_to_gold.cpp
@@ -1,38 +1,213 @@
 #include "Chat.h"
 #include "Player.h"
 #include "ScriptMgr.h"
+#include "j2g_conf.h"
+#include "Item.h"
+#include "SharedDefines.h"
+#include <vector>
+#include <cmath>
+
+// --- Helpers to compare a white-quality loot item with the current equipment (armor & weapons) ---
+static inline int CompareItemTemplates(ItemTemplate const* a, ItemTemplate const* b)
+{
+    // >0: a is better; 0: equal; <0: a is worse
+    if (!a && !b) return 0;
+    if (!a) return -1;
+    if (!b) return 1;
+    if (a->Quality != b->Quality)
+        return int(a->Quality) - int(b->Quality);
+    if (a->ItemLevel != b->ItemLevel)
+        return int(a->ItemLevel) - int(b->ItemLevel);
+    if (a->RequiredLevel != b->RequiredLevel)
+        return int(a->RequiredLevel) - int(b->RequiredLevel);
+    return 0;
+}
+
+static inline bool IsWeaponInvType(uint32 invType)
+{
+    switch (invType)
+    {
+        case INVTYPE_WEAPON:
+        case INVTYPE_WEAPONMAINHAND:
+        case INVTYPE_WEAPONOFFHAND:
+        case INVTYPE_2HWEAPON:
+        case INVTYPE_RANGED:
+        case INVTYPE_RANGEDRIGHT:
+        case INVTYPE_THROWN:
+#ifdef INVTYPE_WAND
+        case INVTYPE_WAND:
+#endif
+            return true;
+        default:
+            return false;
+    }
+}
+
+static inline double ComputeWeaponDPS(ItemTemplate const* proto)
+{
+    if (!proto || proto->Delay == 0)
+        return 0.0;
+    // Use the first valid damage line
+    double minD = 0.0, maxD = 0.0;
+    if (proto->Damage[0].DamageMin > 0.0 || proto->Damage[0].DamageMax > 0.0)
+    {
+        minD = proto->Damage[0].DamageMin;
+        maxD = proto->Damage[0].DamageMax;
+    }
+    else if (proto->Damage[1].DamageMin > 0.0 || proto->Damage[1].DamageMax > 0.0)
+    {
+        minD = proto->Damage[1].DamageMin;
+        maxD = proto->Damage[1].DamageMax;
+    }
+    double avg = (minD + maxD) * 0.5;
+    return (avg * 1000.0) / double(proto->Delay); // dmg per second
+}
+
+static inline int CompareForEquipDecision(ItemTemplate const* a, ItemTemplate const* b, bool weaponPreferredDPS)
+{
+    if (!a && !b) return 0;
+    if (!a) return -1;
+    if (!b) return 1;
+    if (a->Quality != b->Quality)
+        return int(a->Quality) - int(b->Quality);
+    if (weaponPreferredDPS)
+    {
+        double dpsA = ComputeWeaponDPS(a), dpsB = ComputeWeaponDPS(b);
+        if (std::fabs(dpsA - dpsB) > 1e-6)
+            return dpsA > dpsB ? 1 : -1;
+    }
+    if (a->ItemLevel != b->ItemLevel)
+        return int(a->ItemLevel) - int(b->ItemLevel);
+    if (a->RequiredLevel != b->RequiredLevel)
+        return int(a->RequiredLevel) - int(b->RequiredLevel);
+    return 0;
+}
+
+static void GetCandidateSlots(uint32 invType, std::vector<uint8>& slots)
+{
+    switch (invType)
+    {
+        case INVTYPE_HEAD:        slots.push_back(EQUIPMENT_SLOT_HEAD); break;
+        case INVTYPE_NECK:        slots.push_back(EQUIPMENT_SLOT_NECK); break;
+        case INVTYPE_SHOULDERS:   slots.push_back(EQUIPMENT_SLOT_SHOULDERS); break;
+        case INVTYPE_BODY:        slots.push_back(EQUIPMENT_SLOT_BODY); break;     // chemise
+        case INVTYPE_CHEST:       slots.push_back(EQUIPMENT_SLOT_CHEST); break;
+        case INVTYPE_ROBE:        slots.push_back(EQUIPMENT_SLOT_CHEST); break;
+        case INVTYPE_WAIST:       slots.push_back(EQUIPMENT_SLOT_WAIST); break;
+        case INVTYPE_LEGS:        slots.push_back(EQUIPMENT_SLOT_LEGS); break;
+        case INVTYPE_FEET:        slots.push_back(EQUIPMENT_SLOT_FEET); break;
+        case INVTYPE_WRISTS:      slots.push_back(EQUIPMENT_SLOT_WRISTS); break;
+        case INVTYPE_HANDS:       slots.push_back(EQUIPMENT_SLOT_HANDS); break;
+        case INVTYPE_FINGER:      slots.push_back(EQUIPMENT_SLOT_FINGER1); slots.push_back(EQUIPMENT_SLOT_FINGER2); break;
+        case INVTYPE_TRINKET:     slots.push_back(EQUIPMENT_SLOT_TRINKET1); slots.push_back(EQUIPMENT_SLOT_TRINKET2); break;
+        case INVTYPE_CLOAK:       slots.push_back(EQUIPMENT_SLOT_BACK); break;
+        case INVTYPE_SHIELD:      slots.push_back(EQUIPMENT_SLOT_OFFHAND); break;
+        // --- Arms ---
+        case INVTYPE_WEAPON:          // can go in main hand OR off-hand
+            slots.push_back(EQUIPMENT_SLOT_MAINHAND);
+            slots.push_back(EQUIPMENT_SLOT_OFFHAND);
+            break;
+        case INVTYPE_WEAPONMAINHAND:  slots.push_back(EQUIPMENT_SLOT_MAINHAND); break;
+        case INVTYPE_WEAPONOFFHAND:   slots.push_back(EQUIPMENT_SLOT_OFFHAND);  break;
+        case INVTYPE_2HWEAPON:        slots.push_back(EQUIPMENT_SLOT_MAINHAND); break;
+        case INVTYPE_RANGED:
+        case INVTYPE_RANGEDRIGHT:
+        case INVTYPE_THROWN:
+#ifdef INVTYPE_WAND
+        case INVTYPE_WAND:
+#endif
+                                      slots.push_back(EQUIPMENT_SLOT_RANGED);   break;
+        default: break;
+    }
+}
+
+static bool IsWhiteItemWorseThanEquipped(Player* player, ItemTemplate const* proto, bool weapon)
+{
+    if (!player || !proto)
+        return false;
+
+    std::vector<uint8> slots;
+    GetCandidateSlots(proto->InventoryType, slots);
+    if (slots.empty())
+        return false; // non-equippable (not relevant)
+
+    // If any candidate slot is empty OR the loot is >= an equipped item -> don't sell (possible upgrade)
+    bool strictlyWorse = false;
+    for (uint8 slot : slots)
+    {
+        Item* eq = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+        if (!eq)
+            return false; // empty slot -> potentially useful
+        ItemTemplate const* eqProto = eq->GetTemplate();
+        if (CompareForEquipDecision(proto, eqProto, weapon) >= 0)
+            return false; // proto >= an equipped item -> keep it
+        strictlyWorse = true; // proto < eqProto for this slot
+    }
+    return strictlyWorse;
+}
 
 class JunkToGold : public PlayerScript
 {
 public:
     JunkToGold() : PlayerScript("JunkToGold") {}
 
-    void OnPlayerLootItem(Player* player, Item* item, uint32 count, ObjectGuid /*lootguid*/) override
+    //void OnPlayerLootItem(Player* player, Item* item, uint32 count, ObjectGuid /*lootguid*/) override
+	void OnPlayerLootItem(Player* player, Item* item, uint32 count, ObjectGuid /*lootGuid*/) override
     {
-        if (!item || !item->GetTemplate())
-        {
+        // --- Global Toggle ---
+        if (!J2G::IsEnabled())
+            return; // // module off: do nothing
+
+        if (!item)
             return;
+        ItemTemplate const* proto = item->GetTemplate();
+        if (!proto)
+            return;
+
+        bool shouldSell = false;
+        // (1) Grey: always sold
+        if (proto->Quality == ITEM_QUALITY_POOR)
+            shouldSell = true;
+        // (2) White: only (if enabled) when worse than equipped
+        else if (proto->Quality == ITEM_QUALITY_NORMAL)
+        {
+            bool isWeapon = IsWeaponInvType(proto->InventoryType);
+            if (isWeapon && J2G::SellWeaponsIfWorse())
+                shouldSell = IsWhiteItemWorseThanEquipped(player, proto, /*weapon=*/true);
+            else if (!isWeapon && J2G::SellCommonIfWorse())
+                shouldSell = IsWhiteItemWorseThanEquipped(player, proto, /*weapon=*/false);
         }
 
-        if (item->GetTemplate()->Quality == ITEM_QUALITY_POOR)
-        {
-            SendTransactionInformation(player, item, count);
-            player->ModifyMoney(item->GetTemplate()->SellPrice * count);
-            player->DestroyItem(item->GetBagSlot(), item->GetSlot(), true);
-        }
+        if (!shouldSell)
+            return; // we kkep item in bag
+
+        // Sale: info message + gold conversion + removal (once only)
+        SendTransactionInformation(player, item, count);
+        player->ModifyMoney(proto->SellPrice * count);
+        player->DestroyItem(item->GetBagSlot(), item->GetSlot(), true);
     }
 
 private:
     void SendTransactionInformation(Player* player, Item* item, uint32 count)
     {
         std::string name;
+        // Color based on quality (0=grey, 1=white)
+        const char* qColor = "|cff9d9d9d"; // poor
+        switch (item->GetTemplate()->Quality)
+        {
+            case ITEM_QUALITY_NORMAL: qColor = "|cffffffff"; break; // white
+            case ITEM_QUALITY_POOR:   qColor = "|cff9d9d9d"; break; // grey
+            default: break;
+        }
         if (count > 1)
         {
-            name = Acore::StringFormat("|cff9d9d9d|Hitem:{}::::::::80:::::|h[{}]|h|rx{}", item->GetTemplate()->ItemId, item->GetTemplate()->Name1, count);
+            name = Acore::StringFormat("{}|Hitem:{}::::::::80:::::|h[{}]|h|rx{}",
+                                       qColor, item->GetTemplate()->ItemId, item->GetTemplate()->Name1, count);
         }
         else
         {
-            name = Acore::StringFormat("|cff9d9d9d|Hitem:{}::::::::80:::::|h[{}]|h|r", item->GetTemplate()->ItemId, item->GetTemplate()->Name1);
+            name = Acore::StringFormat("{}|Hitem:{}::::::::80:::::|h[{}]|h|r",
+                                       qColor, item->GetTemplate()->ItemId, item->GetTemplate()->Name1);
         }
 
         uint32 money = item->GetTemplate()->SellPrice * count;
@@ -82,5 +257,9 @@ private:
 
 void Addmod_junk_to_goldScripts()
 {
+    J2G::LoadConfig();
+
+    new J2G::World();
+	
     new JunkToGold();
 }


### PR DESCRIPTION
Add Config file + smarter auto-sell + Human player detection

Summary :

New config file (conf/mod_junk_to_gold.conf.dist) with runtime reload.

Enable/disable switch: JunkToGold.Enable (1 on / 0 off).

White items auto-sell (opt-in): JunkToGold.SellCommonIfWorse=1 => sell if strictly worse than equipped.

White weapons auto-sell (opt-in): JunkToGold.SellWeaponsIfWorse=1 => DPS-aware, sell if strictly worse.

Sell only for bots or Human and bots: JunkToGold.EnableForHumans= 1 => Selling for booth

Backwards compatible: defaults keep current behavior (sell greys only).

Config (example):

[worldserver]
JunkToGold.Enable = 1
JunkToGold.Announce = 1
JunkToGold.SellCommonIfWorse = 0
JunkToGold.SellWeaponsIfWorse = 0
JunkToGold.EnableForHumans = 1